### PR TITLE
Enable global filters, add global custom RpcException filter

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -5,6 +5,8 @@ import { ConfigModule, ConfigService } from '@nestjs/config'
 import { AppController } from './app.controller'
 import { AppService } from './app.service'
 import configuration from './config/configuration'
+import { APP_FILTER } from '@nestjs/core'
+import { CustomRpcExceptionFilter } from './filters/rpc-exception.filter'
 
 @Module({
   imports: [
@@ -26,6 +28,9 @@ import configuration from './config/configuration'
     DemoModule
   ],
   controllers: [AppController],
-  providers: [AppService]
+  providers: [
+    AppService,
+    { provide: APP_FILTER, useClass: CustomRpcExceptionFilter }
+  ]
 })
 export class AppModule {}

--- a/src/filters/rpc-exception.filter.ts
+++ b/src/filters/rpc-exception.filter.ts
@@ -1,0 +1,16 @@
+import { Catch, RpcExceptionFilter, ArgumentsHost } from '@nestjs/common'
+import { Observable, throwError } from 'rxjs'
+import { RpcException } from '@nestjs/microservices'
+
+@Catch(RpcException)
+export class CustomRpcExceptionFilter implements RpcExceptionFilter<RpcException> {
+  catch (exception: RpcException, host: ArgumentsHost): Observable<any> {
+    const obj = exception.getError()
+
+    if (typeof obj === 'object' && obj != null) {
+      return throwError({ type: RpcException.name, ...obj })
+    }
+
+    return throwError({ type: RpcException.name, message: obj })
+  }
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -11,12 +11,15 @@ async function bootstrap () {
   const configService = app.get<ConfigService<AppConfig>>(ConfigService)
   const PORT = configService.get<number>('port', 3000)
 
-  app.connectMicroservice<MicroserviceOptions>({
-    transport: Transport.MQTT,
-    options: {
-      ...configService.get('mqtt')
-    }
-  })
+  app.connectMicroservice<MicroserviceOptions>(
+    {
+      transport: Transport.MQTT,
+      options: {
+        ...configService.get('mqtt')
+      }
+    },
+    { inheritAppConfig: true }
+  )
 
   await app.startAllMicroservicesAsync()
   await app.listen(PORT)


### PR DESCRIPTION
Since the Engine is a [Nest.js Hybrid App](https://docs.nestjs.com/faq/hybrid-application), it does not have global filters, interceptors, pipes, etc., enabled by default. This would have meant duplicate code in each of the integration modules for things that could be defined just once (e.g. the `CustomRpcExceptionFilter` that was added). This PR addresses that.

See related PRs:
- https://github.com/nominal-systems/dmi-engine-demo-provider/pull/1
- https://github.com/nominal-systems/dmi-engine-idexx-integration/pull/1
- https://github.com/nominal-systems/dmi-engine-antech-integration/pull/1
- https://github.com/nominal-systems/dmi-engine-zoetis-integration/pull/7