### PR TITLE
Fix Dockerfile 'production' stage not working

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,6 +27,5 @@ ENV NODE_ENV=production
 COPY --from=build /app/dist .
 COPY --from=build /app/node_modules .
 COPY --from=build /app/package.json .
-RUN npm prune --production
 EXPOSE 3000
 CMD ["npm", "run", "start:prod"]

--- a/Dockerfile.tilt
+++ b/Dockerfile.tilt
@@ -26,6 +26,5 @@ ENV NODE_ENV=production
 COPY --from=build /app/dist .
 COPY --from=build /app/node_modules .
 COPY --from=build /app/package.json .
-RUN npm prune --production
 EXPOSE 3000
 CMD ["npm", "run", "start:prod"]


### PR DESCRIPTION
Apparently, because of the way NPM handles versions below 1 (e.g. `0.1.2`) when handling semver (semver does not include versions below 1) for installing/updating, it seems to also apply for `npm prune` command, which incorrectly made it delete production dependencies that were not necessarily `devDependencies` (even though the `--production` flag was passed). Removing the `npm prune --production` step from Dockerfile allows the stage to work again.