### PR TITLE
Add keepAlive option to Redis connection for improved stability

### DIFF
--- a/src/redis/redis.factory.ts
+++ b/src/redis/redis.factory.ts
@@ -47,6 +47,7 @@ export const createBullRedisOptions = (configService: ConfigService, logger = ne
     ...(tls !== undefined ? { tls } : {}),
     enableReadyCheck: false,
     maxRetriesPerRequest: null,
+    keepAlive: 5000,
     ...(connectTimeoutMs !== undefined && !Number.isNaN(connectTimeoutMs) ? { connectTimeout: connectTimeoutMs } : {})
   }
 


### PR DESCRIPTION
In production, Redis connections are occasionally dropped silently by the network                                                                                                                                                                                        
  layer (Azure Load Balancer), causing Bull queue operations to fail with `ECONNRESET`                                                                                                                                                                                     
  or hang indefinitely. This surfaces as 503s to clients or unresponsive `/queues`                                                                                                                                                                                         
  endpoints.                                                                                                                                                                                                                                                               
                                                                                                                                                                                                                                                                           
  ### Possible root cause                                                                                                                                                                                                                                                            
                                                                                                                                                                                                                                                                         
  Azure Load Balancer has a 4-minute idle TCP timeout. Bull creates 3 Redis                                                                                                                                                                                            
  connections per queue (client, subscriber, bclient). When these connections sit                                                                                                                                                                                        
  idle — no jobs running, no commands being issued — they go silent. After 4 minutes                                                                                                                                                                                       
  of no TCP traffic, Azure LB silently closes the socket from its side. The next                                                                                                                                                                                           
  command the engine sends on that connection fails with `ECONNRESET` or blocks                                                                                                                                                                                            
  indefinitely until the job is manually restarted.                                                                                                                                                                                                                                                            
                                                                                                                                                                                                                                                                           
  ### Fix
                                                                                                                                                                                                                                                                         
  Added `keepAlive: 5000` to `baseRedisOptions` in `src/redis/redis.factory.ts`.                                                                                                                                                                                           
                                                                                                                                                                                                                                                                         
  TCP keepalive sends a small probe packet every 5 seconds on idle connections,                                                                                                                                                                                            
  resetting Azure LB's idle timer before it ever expires. The connection stays                                                                                                                                                                                           
  "warm" indefinitely. The probe packets are ~40 bytes with no payload, so the                                                                                                                                                                                        
  overhead is small. 