### PR TITLE
Enhance job queue configuration and settings

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -43,7 +43,40 @@ import { statsigFeatureFlagProvider } from './feature-flags/statsig-feature-flag
         disabled: process.env.ANTECH_V6_DISABLED === 'true' || false
       },
       'wisdom-panel': {
-        queues: [{ name: 'wisdom-panel.results' }, { name: 'wisdom-panel.orders' }],
+        queues: [
+          {
+            name: 'wisdom-panel.results',
+            defaultJobOptions: {
+              removeOnComplete: true,
+              removeOnFail: false,
+              attempts: 3,
+              backoff: {
+                type: 'exponential',
+                delay: 5000
+              }
+            },
+            settings: {
+              lockDuration: 120000,
+              maxStalledCount: 2
+            }
+          },
+          {
+            name: 'wisdom-panel.orders',
+            defaultJobOptions: {
+              removeOnComplete: true,
+              removeOnFail: false,
+              attempts: 3,
+              backoff: {
+                type: 'exponential',
+                delay: 5000
+              }
+            },
+            settings: {
+              lockDuration: 120000,
+              maxStalledCount: 2
+            }
+          }
+        ],
         providerModule: WisdomPanelModule.register(),
         disabled: process.env.WISDOM_PANEL_DISABLED === 'true' || false,
         options: {


### PR DESCRIPTION
  - Configure Wisdom Panel Bull queues (wisdom-panel.orders, wisdom-panel.results) with retry and stall detection settings                                                                                                                                                  
  - Jobs now retry up to 3 times with exponential backoff (5s, 10s, 20s) before being marked as failed
  - Increase `lockDuration` from the default 30s to 120s (2 min) to prevent false stall detection when the Wisdom Panel API is slow to respond, this was likely the root cause of integrations silently stopping                                                             
  - Set `maxStalledCount: 2` to give stalled jobs a second chance before failing                                                                                                                                                                                              
  - Set `removeOnFail: false` to retain failed jobs in Redis for debugging                                                                                                                                                                                                    
                                                                                                                                                                                                                                                                            
  Related: nominal-systems/dmi-engine-wisdom-panel-integration#18                                                                                                                                                                                                           
