### PR TITLE
Bump @nominal-systems/dmi-engine-common to v1.2.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "@nestjs/microservices": "^10.3.2",
         "@nestjs/platform-express": "^10.3.2",
         "@nominal-systems/dmi-engine-antech-v6-integration": "^0.4.18",
-        "@nominal-systems/dmi-engine-common": "^1.1.9",
+        "@nominal-systems/dmi-engine-common": "^1.2.0",
         "@nominal-systems/dmi-engine-wisdom-panel-integration": "^0.3.14",
         "bull": "^4.12.2",
         "cache-manager": "^5.5.1",
@@ -2184,9 +2184,9 @@
       }
     },
     "node_modules/@nominal-systems/dmi-engine-common": {
-      "version": "1.1.9",
-      "resolved": "https://npm.pkg.github.com/download/@nominal-systems/dmi-engine-common/1.1.9/abb942367e47bf0eaff173724ca792453cafd6e4",
-      "integrity": "sha512-sZurvGqxZFOnj1fOK0cCBPZpD9tfaDOjxiZ0Obg2QgRB1wCxcElHfxzrkzLN56FoWosbjfQ4BzrfHJTfpLGwKQ==",
+      "version": "1.2.0",
+      "resolved": "https://npm.pkg.github.com/download/@nominal-systems/dmi-engine-common/1.2.0/970a29d5c0a119a903ff77cef49ba9e0a28ebbf2",
+      "integrity": "sha512-u+fZ6IvVWE2Ri92pVZ8ZZGuRIELJSFP0IezDSShcMUBWAn26hLFefhBcYEHG4DGnTu2do4nU3WLASZs8uRCSkw==",
       "license": "ISC",
       "dependencies": {
         "@nestjs/axios": "^3.0.2",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "@nestjs/microservices": "^10.3.2",
     "@nestjs/platform-express": "^10.3.2",
     "@nominal-systems/dmi-engine-antech-v6-integration": "^0.4.18",
-    "@nominal-systems/dmi-engine-common": "^1.1.9",
+    "@nominal-systems/dmi-engine-common": "^1.2.0",
     "@nominal-systems/dmi-engine-wisdom-panel-integration": "^0.3.14",
     "bull": "^4.12.2",
     "cache-manager": "^5.5.1",


### PR DESCRIPTION
## Summary

Bump \`@nominal-systems/dmi-engine-common\` from \`^1.1.9\` to \`^1.2.0\`.

## Notes

Non-breaking upgrade. v1.2.0 adds compat softenings and a \`ProviderIntegrationV0\` alias; no API removals.

Closes #62